### PR TITLE
feat: pass dynamic secrets

### DIFF
--- a/.github/workflows/accept-dynamic-secret.yml
+++ b/.github/workflows/accept-dynamic-secret.yml
@@ -1,0 +1,23 @@
+# This workflow accepts a secret and prints the length of its value. There's
+# nothing special about what happens here, but the calling workflows
+# demonstrate the capability to dynamically select a secret to be passed to a
+# reusable workflow.
+name: Accept Dynamic Secret
+on:
+  workflow_call:
+    inputs:
+      dynamic-secret-name:
+        description: The name of the secret whose value is passed to secrts.dynamic-secret-value
+        required: true
+        type: string
+    secrets:
+      dynamic-secret-value:
+        description: The value of the dynamically-passed secret
+        required: true
+jobs:
+  print-dynamic-secret-name-and-length:
+    name: Print Dynamic Secret Name And Length
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print Dynamic Secret Name And Length
+        run: echo "The value of the secret '${{ inputs.dynamic-secret-name }}' contains $(echo -n ${{ secrets.dynamic-secret-value }} | wc -c) characters."

--- a/.github/workflows/pass-dynamic-secrets.yml
+++ b/.github/workflows/pass-dynamic-secrets.yml
@@ -1,0 +1,29 @@
+# This workflow calls a reusable workflow in a matrix, passing secrets that
+# were dynamically selected from the output of another job.
+name: Pass Dynamically Selected Secrets To Reusable Workflow
+on: [push]
+jobs:
+  get-dynamic-secret-names:
+    name: Get Dynamic Secret Names
+    runs-on: ubuntu-latest
+    outputs:
+      dynamic-secret-names: ${{ steps.get-dynamic-secret-names.outputs.dynamic-secret-names }}
+    steps:
+      - id: get-dynamic-secret-names
+        name: Get Dynamic Secret Names
+        run: |
+          echo "dynamic-secret-names=['DYNAMIC_SECRET_WITH_LEN_8', 'DYNAMIC_SECRET_WITH_LEN_13', 'DYNAMIC_SECRET_WITH_LEN_21']" >> $GITHUB_OUTPUT
+  pass-dynamic-secret:
+    uses: ./.github/workflows/accept-dynamic-secret.yml
+    needs:
+      - get-dynamic-secret-names
+    strategy:
+      max-parallel: 10
+      fail-fast: true
+      matrix:
+        dynamic-secret-name: ${{ fromJson(needs.get-dynamic-secret-names.outputs.dynamic-secret-names) }}
+    name: Accept Dynamic Secret (${{ matrix.dynamic-secret-name }})
+    with:
+      dynamic-secret-name: ${{ matrix.dynamic-secret-name }}
+    secrets:
+      dynamic-secret-value: ${{ secrets[matrix.dynamic-secret-name] }}

--- a/scripts/wc-secret-env-var.sh
+++ b/scripts/wc-secret-env-var.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 set -x
-echo "${SECRET}" | wc -c
+echo -n "${SECRET}" | wc -c


### PR DESCRIPTION
This workflow produces a list of secret names dynamically within one of its jobs as an output (the list is static, but the consumer of the output doesn't know that), then passes the corresponding secrets to a reusable workflow by name.